### PR TITLE
feat: add support for parquet and arrow storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements/dev.txt
-          python -m pip install -e .
+          python -m pip install -e .[test]
       - name: run RStudio Connect
         run: |
           docker-compose up --build -d

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -255,6 +255,8 @@ def board_github(
     Examples
     --------
 
+    >>> import pytest; pytest.skip()
+
     >>> import os
     >>> board = board_github("machow", "pins-python", "pins/tests/pins-compat")
     >>> board.pin_list()

--- a/pins/tests/test_drivers.py
+++ b/pins/tests/test_drivers.py
@@ -45,7 +45,15 @@ def test_default_title(obj, dst_title):
     assert res == dst_title
 
 
-def test_driver_roundtrip_csv(tmp_dir2):
+@pytest.mark.parametrize(
+    "type_",
+    [
+        "csv",
+        "feather",
+        "parquet",
+    ],
+)
+def test_driver_roundtrip(tmp_dir2, type_):
     # TODO: I think this test highlights the challenge of getting the flow
     # between metadata, drivers, and the metafactory right.
     # There is the name of the data (relative to the pin directory), and the full
@@ -55,14 +63,14 @@ def test_driver_roundtrip_csv(tmp_dir2):
     df = pd.DataFrame({"x": [1, 2, 3]})
 
     fname = "some_df"
-    type_ = "csv"
+    full_file = f"{fname}.{type_}"
 
     p_obj = tmp_dir2 / fname
     res_fname = save_data(df, p_obj, type_)
 
-    assert Path(res_fname).name == f"{fname}.csv"
+    assert Path(res_fname).name == full_file
 
-    meta = MetaRaw(f"{fname}.csv", type_, "my_pin")
+    meta = MetaRaw(full_file, type_, "my_pin")
     obj = load_data(meta, fsspec.filesystem("file"), tmp_dir2)
 
     assert df.equals(obj)

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,8 @@ test =
     pytest-dotenv
     s3fs
     adlfs
+    fastparquet
+    pyarrow
 
 
 [bdist_wheel]


### PR DESCRIPTION
This PR 

* adds the storage types "feather" and "parquet", which delegate to pandas.DataFrame.to_parquet/feather, and pandas.read_parquet/feather..!
* skips a test that was hitting the github API, causing rate limit errors