### PR TITLE
Update intro.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
     name: "Preview Docs:"
     runs-on: ubuntu-latest
     needs: ["build-docs"]
-    if: "{{github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}"
+    if: "${{github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}"
 
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,8 @@ jobs:
     name: "Preview Docs:"
     runs-on: ubuntu-latest
     needs: ["build-docs"]
-    if: github.event_name == 'pull_request'
+    if: "{{github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork }}"
+
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Run tests
         run: |
           # TODO: better way to disable all cloud backend tests?
-          pytest pins -m 'not fs_rsc and not fs_s3 and not skip_on_github'
+          pytest pins -m 'not fs_rsc and not fs_s3 and not fs_gcs and not skip_on_github'
 
 
   check-cross-compatibility:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,7 +20,7 @@ kernelspec:
 :alt: pins, a library for organizing and sharing data.
 ```
 
-The pins package publishes data, models, and other R objects, making it easy to share them across projects and with your colleagues.
+The pins package publishes data, models, and other Python objects, making it easy to share them across projects and with your colleagues.
 You can pin objects to a variety of pin *boards*, including folders (to share on a networked drive or with services like DropBox), RStudio Connect, Amazon S3, Azure storage and ~~Microsoft 365 (OneDrive and SharePoint)~~.
 Pins can be automatically versioned, making it straightforward to track changes, re-run analyses on historical data, and undo mistakes.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,8 +20,8 @@ kernelspec:
 :alt: pins, a library for organizing and sharing data.
 ```
 
-The pins package publishes data, models, and other Python objects, making it easy to share them across projects and with your colleagues.
-You can pin objects to a variety of pin *boards*, including folders (to share on a networked drive or with services like DropBox), RStudio Connect, Amazon S3, Azure storage and ~~Microsoft 365 (OneDrive and SharePoint)~~.
+The pins package publishes data, models, and other Python objects, making it easy to share
+You can pin objects to a variety of pin *boards*, including folders (to share on a networked drive or with services like DropBox), RStudio Connect, Amazon S3, and Google Cloud Storage.
 Pins can be automatically versioned, making it straightforward to track changes, re-run analyses on historical data, and undo mistakes.
 
 ## Installation
@@ -96,5 +96,5 @@ board.pin_read("hadley/sales-summary")
 
 You can easily control who gets to access the data using the RStudio Connect permissions pane.
 
-The pins package also includes boards that allow you to share data on services like Amazon's S3 (`board_s3()`) and Azure's blob storage (`board_azure()`).
+The pins package also includes boards that allow you to share data on services like Amazon's S3 (`board_s3()`) and Google Cloud Storage (`board_gcs()`).
 Learn more in [getting started](getting_started.Rmd).

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -388,7 +388,7 @@ def board_s3(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
 
 
 def board_gcs(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
-    """Create a board to read and write pins from an AWS S3 bucket folder.
+    """Create a board to read and write pins from an Google Cloud Storage bucket folder.
 
     Parameters
     ----------


### PR DESCRIPTION
- Copy/Paste update R <>Python
- Are Azure and Microsoft 365 supported boards? The MSFT 365 note is formatted strangely right now. There's also a mention of Azure as a board at the bottom of the doc, but I don't see functions to support it yet. 