### PR TITLE
feat: azure backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: "us-east-1"
+          AZURE_STORAGE_ACCOUNT_NAME: ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }}
+          AZURE_STORAGE_ACCOUNT_KEY: ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }}
           PYTEST_OPTS: ${{ matrix.pytest_opts }}
           REQUIREMENTS: ${{ matrix.requirements }}
           # fixes error on macosx virtual machine with pytest-parallel

--- a/docs/api/constructors.rst
+++ b/docs/api/constructors.rst
@@ -11,5 +11,6 @@ Board Constructors
    ~board_temp
    ~board_s3
    ~board_gcs
+   ~board_azure
    ~board_rsconnect
    ~board

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -38,6 +38,10 @@ Boards abstract over different storage backends, making it easy to share data in
      - Use RStudio Connect as a board
    * - :func:`.board_s3`
      - Use an S3 bucket as a board
+   * - :func:`.board_gcs`
+     - Use an Google Cloud Storage bucket as a board
+   * - :func:`.board_azure`
+     - Use an Azure Datalake storage container as a board.
    * - :func:`.board`
      - Generic board constructor
 

--- a/docs/getting_started.Rmd
+++ b/docs/getting_started.Rmd
@@ -22,7 +22,7 @@ Getting Started
 
 The pins package helps you publish data sets, models, and other Python objects, making it easy to share them across projects and with your colleagues.
 You can pin objects to a variety of "boards", including local folders (to share on a networked drive or with DropBox), RStudio connect, Amazon S3,
-Google Cloud Storage, and more.
+Google Cloud Storage, Azure Datalake, and more.
 This vignette will introduce you to the basics of pins.
 
 ```{python}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -21,7 +21,7 @@ kernelspec:
 ```
 
 The pins package publishes data, models, and other Python objects, making it easy to share
-You can pin objects to a variety of pin *boards*, including folders (to share on a networked drive or with services like DropBox), RStudio Connect, Amazon S3, and Google Cloud Storage.
+You can pin objects to a variety of pin *boards*, including folders (to share on a networked drive or with services like DropBox), RStudio Connect, Amazon S3, Google Cloud Storage, and Azure Datalake.
 Pins can be automatically versioned, making it straightforward to track changes, re-run analyses on historical data, and undo mistakes.
 
 ## Installation
@@ -96,5 +96,6 @@ board.pin_read("hadley/sales-summary")
 
 You can easily control who gets to access the data using the RStudio Connect permissions pane.
 
-The pins package also includes boards that allow you to share data on services like Amazon's S3 (`board_s3()`) and Google Cloud Storage (`board_gcs()`).
+The pins package also includes boards that allow you to share data on services like
+Amazon's S3 (`board_s3()`), Google Cloud Storage (`board_gcs()`), and Azure Datalake (`board_azure()`).
 Learn more in [getting started](getting_started.Rmd).

--- a/pins/__init__.py
+++ b/pins/__init__.py
@@ -18,6 +18,7 @@ from .constructors import (
     board_github,
     board_urls,
     board_rsconnect,
+    board_azure,
     board_s3,
     board_gcs,
     board,

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -111,8 +111,8 @@ def board(
     board_factory:
         An optional board class to use as the constructor.
 
-    Note
-    ----
+    Notes
+    -----
     Many fsspec implementations of filesystems cache the searching of files, which may
     cause you to not see pins saved by other people. Disable this on these file systems
     with `storage_options = {"listings_expiry_time": 0}` on s3, or `{"cache_timeout": 0}`
@@ -256,8 +256,8 @@ def board_github(
     **kwargs:
         Passed to the pins.board function.
 
-    Note
-    ----
+    Notes
+    -----
     This board is read only.
 
 
@@ -374,8 +374,8 @@ def board_s3(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
     **kwargs:
         Passed to the pins.board function.
 
-    Note
-    ----
+    Notes
+    -----
     The s3 board uses the fsspec library (s3fs) to handle interacting with s3.
     In order to authenticate, set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
     and (optionally) AWS_REGION environment variables.
@@ -397,8 +397,8 @@ def board_gcs(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
     **kwargs:
         Passed to the pins.board function.
 
-    Note
-    ----
+    Notes
+    -----
     The gcs board uses the fsspec library (gcsfs) to handle interacting with
     google cloud storage. Currently, its default mode of authentication
     is supported.
@@ -413,5 +413,23 @@ def board_gcs(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
 
 
 def board_azure(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
+    """Create a board to read and write pins from an Google Cloud Storage bucket folder.
+
+    Parameters
+    ----------
+    path:
+        Path of form <bucket_name>/<optional>/<subdirectory>.
+    **kwargs:
+        Passed to the pins.board function.
+
+    Notes
+    -----
+    The azure board uses the fsspec library (adlfs) to handle interacting with
+    Azure Datalake Filesystem (adl). Currently, its default mode of authentication
+    is supported.
+
+    See https://github.com/fsspec/adlfs
+    """
+
     opts = {"use_listings_cache": False}
-    return board("az", path, versioned, cache, allow_pickle_read, storage_options=opts)
+    return board("adl", path, versioned, cache, allow_pickle_read, storage_options=opts)

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -410,3 +410,8 @@ def board_gcs(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
     # fixes it under the hood
     opts = {"cache_timeout": 0}
     return board("gcs", path, versioned, cache, allow_pickle_read, storage_options=opts)
+
+
+def board_azure(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
+    opts = {"use_listings_cache": False}
+    return board("az", path, versioned, cache, allow_pickle_read, storage_options=opts)

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -425,11 +425,13 @@ def board_azure(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
     Notes
     -----
     The azure board uses the fsspec library (adlfs) to handle interacting with
-    Azure Datalake Filesystem (adl). Currently, its default mode of authentication
+    Azure Datalake Filesystem (abfs). Currently, its default mode of authentication
     is supported.
 
     See https://github.com/fsspec/adlfs
     """
 
     opts = {"use_listings_cache": False}
-    return board("adl", path, versioned, cache, allow_pickle_read, storage_options=opts)
+    return board(
+        "abfs", path, versioned, cache, allow_pickle_read, storage_options=opts
+    )

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -380,6 +380,8 @@ def board_s3(path, versioned=True, cache=DEFAULT, allow_pickle_read=None):
     In order to authenticate, set the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
     and (optionally) AWS_REGION environment variables.
 
+    See https://github.com/fsspec/s3fs
+
     """
     # TODO: user should be able to specify storage options here?
 

--- a/pins/tests/conftest.py
+++ b/pins/tests/conftest.py
@@ -14,14 +14,14 @@ EXAMPLE_PIN_NAME = "df_csv"
 
 
 # Based on https://github.com/machow/siuba/blob/main/siuba/tests/helpers.py
-BACKEND_MARKS = ["fs_s3", "fs_file", "fs_gcs", "fs_adl", "fs_rsc"]
+BACKEND_MARKS = ["fs_s3", "fs_file", "fs_gcs", "fs_abfs", "fs_rsc"]
 
 # parameters that can be used more than once per session
 params_safe = [
     pytest.param(lambda: BoardBuilder("file"), id="file", marks=m.fs_file),
     pytest.param(lambda: BoardBuilder("s3"), id="s3", marks=m.fs_s3),
     pytest.param(lambda: BoardBuilder("gcs"), id="gcs", marks=m.fs_gcs),
-    pytest.param(lambda: BoardBuilder("adl"), id="adl", marks=m.fs_adl),
+    pytest.param(lambda: BoardBuilder("abfs"), id="abfs", marks=m.fs_abfs),
 ]
 
 # rsc should only be used once, because users are created at docker setup time

--- a/pins/tests/conftest.py
+++ b/pins/tests/conftest.py
@@ -14,14 +14,14 @@ EXAMPLE_PIN_NAME = "df_csv"
 
 
 # Based on https://github.com/machow/siuba/blob/main/siuba/tests/helpers.py
-BACKEND_MARKS = ["fs_s3", "fs_file", "fs_gcs", "fs_azure", "fs_rsc"]
+BACKEND_MARKS = ["fs_s3", "fs_file", "fs_gcs", "fs_adl", "fs_rsc"]
 
 # parameters that can be used more than once per session
 params_safe = [
     pytest.param(lambda: BoardBuilder("file"), id="file", marks=m.fs_file),
     pytest.param(lambda: BoardBuilder("s3"), id="s3", marks=m.fs_s3),
     pytest.param(lambda: BoardBuilder("gcs"), id="gcs", marks=m.fs_gcs),
-    pytest.param(lambda: BoardBuilder("az"), id="azure", marks=m.fs_azure),
+    pytest.param(lambda: BoardBuilder("adl"), id="adl", marks=m.fs_adl),
 ]
 
 # rsc should only be used once, because users are created at docker setup time

--- a/pins/tests/conftest.py
+++ b/pins/tests/conftest.py
@@ -14,13 +14,14 @@ EXAMPLE_PIN_NAME = "df_csv"
 
 
 # Based on https://github.com/machow/siuba/blob/main/siuba/tests/helpers.py
-BACKEND_MARKS = ["fs_s3", "fs_file", "fs_gcs", "fs_rsc"]
+BACKEND_MARKS = ["fs_s3", "fs_file", "fs_gcs", "fs_azure", "fs_rsc"]
 
 # parameters that can be used more than once per session
 params_safe = [
     pytest.param(lambda: BoardBuilder("file"), id="file", marks=m.fs_file),
     pytest.param(lambda: BoardBuilder("s3"), id="s3", marks=m.fs_s3),
-    pytest.param(lambda: BoardBuilder("gcs"), id="s3", marks=m.fs_gcs),
+    pytest.param(lambda: BoardBuilder("gcs"), id="gcs", marks=m.fs_gcs),
+    pytest.param(lambda: BoardBuilder("az"), id="azure", marks=m.fs_azure),
 ]
 
 # rsc should only be used once, because users are created at docker setup time

--- a/pins/tests/helpers.py
+++ b/pins/tests/helpers.py
@@ -25,11 +25,8 @@ BOARD_CONFIG = {
     "file": {"path": ["PINS_TEST_FILE__PATH", None]},
     "s3": {"path": ["PINS_TEST_S3__PATH", "ci-pins"]},
     "gcs": {"path": ["PINS_TEST_GCS__PATH", "ci-pins"]},
+    "az": {"path": ["PINS_TEST_AZURE__PATH", "ci-pins"]},
     "rsc": {"path": ["PINS_TEST_RSC__PATH", RSC_SERVER_URL]},
-    # TODO(question): R pins has the whole server a board
-    # but it's a bit easier to test by (optionally) allowing a user
-    # or something else to be a board
-    # "rsc": {"path": ["PINS_TEST_RSC__PATH", ""]}
 }
 
 # TODO: Backend initialization should be independent of helpers, but these
@@ -121,7 +118,7 @@ class BoardBuilder:
         if self.fs_name == "gcs":
             opts = {"cache_timeout": 0}
         else:
-            opts = {"listings_expiry_time": 0}
+            opts = {"use_listings_cache": False}
 
         fs = filesystem(self.fs_name, **opts)
         temp_name = str(uuid.uuid4())

--- a/pins/tests/helpers.py
+++ b/pins/tests/helpers.py
@@ -25,7 +25,7 @@ BOARD_CONFIG = {
     "file": {"path": ["PINS_TEST_FILE__PATH", None]},
     "s3": {"path": ["PINS_TEST_S3__PATH", "ci-pins"]},
     "gcs": {"path": ["PINS_TEST_GCS__PATH", "ci-pins"]},
-    "az": {"path": ["PINS_TEST_AZURE__PATH", "ci-pins"]},
+    "adl": {"path": ["PINS_TEST_AZURE__PATH", "ci-pins"]},
     "rsc": {"path": ["PINS_TEST_RSC__PATH", RSC_SERVER_URL]},
 }
 

--- a/pins/tests/helpers.py
+++ b/pins/tests/helpers.py
@@ -25,7 +25,7 @@ BOARD_CONFIG = {
     "file": {"path": ["PINS_TEST_FILE__PATH", None]},
     "s3": {"path": ["PINS_TEST_S3__PATH", "ci-pins"]},
     "gcs": {"path": ["PINS_TEST_GCS__PATH", "ci-pins"]},
-    "adl": {"path": ["PINS_TEST_AZURE__PATH", "ci-pins"]},
+    "abfs": {"path": ["PINS_TEST_AZURE__PATH", "ci-pins"]},
     "rsc": {"path": ["PINS_TEST_RSC__PATH", RSC_SERVER_URL]},
 }
 

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -38,6 +38,8 @@ def construct_from_board(board):
         board = c.board_rsconnect(
             server_url=board.fs.api.server_url, api_key=board.fs.api.api_key
         )
+    elif fs_name == "abfs":
+        board = c.board_azure(board.board)
     else:
         board = getattr(c, f"board_{fs_name}")(board.board)
 
@@ -207,6 +209,8 @@ def test_constructor_boards_multi_user(board2, df_csv, tmp_cache):
         # TODO: RSConnect writes pin names like <user>/<name>, so would need to
         # modify test
         pytest.skip()
+    elif fs_name == "abfs":
+        fs_name = "azure"
 
     first = construct_from_board(board2)
 

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -38,7 +38,7 @@ def construct_from_board(board):
         board = c.board_rsconnect(
             server_url=board.fs.api.server_url, api_key=board.fs.api.api_key
         )
-    elif fs_name == "abfs":
+    elif fs_name == "adl":
         board = c.board_azure(board.board)
     else:
         board = getattr(c, f"board_{fs_name}")(board.board)

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -38,7 +38,7 @@ def construct_from_board(board):
         board = c.board_rsconnect(
             server_url=board.fs.api.server_url, api_key=board.fs.api.api_key
         )
-    elif fs_name == "adl":
+    elif fs_name == "abfs":
         board = c.board_azure(board.board)
     else:
         board = getattr(c, f"board_{fs_name}")(board.board)


### PR DESCRIPTION
Initial implementation of azure backend.

TODO:

- [x] : ~should I use use_listings_cache=False, rather than listings_expiry_time=0?~ (yes!)
- [x] clean up, decide how we refer to azure in tests
- [x] fix constructor tests, which try to use the fsspec protocol to figure out the constructor name (e.g. s3 -> board_s3, but azure's protocol is e.g. abfs, while the constructor is board_azure)
- [x] take a quick crack at https://github.com/fsspec/filesystem_spec/issues/987. (We resolved by using `use_listings_cache=False`). **edit**: opened a PR (https://github.com/fsspec/filesystem_spec/pull/1027), which this PR does not need to wait on.