### PR TITLE
feat!: support public rsc pin read, using manual board

### DIFF
--- a/docs/api/constructors.rst
+++ b/docs/api/constructors.rst
@@ -12,4 +12,5 @@ Board Constructors
    ~board_s3
    ~board_gcs
    ~board_rsconnect
+   ~board_url
    ~board

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -32,12 +32,18 @@ Boards abstract over different storage backends, making it easy to share data in
 .. list-table::
    :class: table-align-left
 
-   * - :func:`.board_folder`, :func:`.board_local`
+   * - :func:`.board_azure`
+     - Use an Azure storage container as a board
+   * - :func:`.board_folder`, :func:`.board_local`, :func:`.board_temp`
      - Use a local folder as a board
    * - :func:`.board_rsconnect`
      - Use RStudio Connect as a board
    * - :func:`.board_s3`
      - Use an S3 bucket as a board
+   * - :func:`.board_gcs`
+     - Use a Google Cloud Storage bucket as a board.
+   * - :func:`.board_url`
+     - Use a dictionary of URLs as a board
    * - :func:`.board`
      - Generic board constructor
 

--- a/pins/__init__.py
+++ b/pins/__init__.py
@@ -16,7 +16,8 @@ from .constructors import (
     board_temp,
     board_local,
     board_github,
-    board_urls,
+    board_urls,  # DEPRECATED
+    board_url,
     board_rsconnect,
     board_s3,
     board_gcs,

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -730,7 +730,11 @@ class BoardManual(BaseBoard):
                     f" single file. Cannot construct a path to elements {elements}."
                 )
             return "/".join(pre_components + [pin_path])
-        elif len(others) == 0:
+
+        # handle paths to pins (i.e. end with /) ----
+        stripped = pin_path[:-1]
+
+        if len(others) == 0:
             return "/".join(pre_components + [pin_path])
         elif len(others) == 1:
             version = others[0]
@@ -738,7 +742,7 @@ class BoardManual(BaseBoard):
         elif len(others) == 2:
             version, meta = others
 
-            return "/".join(pre_components + [pin_path, meta])
+            return "/".join(pre_components + [stripped, meta])
 
         raise NotImplementedError(
             f"Unable to construct path from these elements: {elements}"

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -289,7 +289,18 @@ def board_github(
     )
 
 
-def board_urls(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None):
+def board_urls(*args, **kwargs):
+    """DEPRECATED: This board has been renamed to board_url."""
+    from .utils import warn_deprecated
+
+    warn_deprecated(
+        "board_urls has been renamed to board_url. Please use board_url instead."
+    )
+
+    return board_url(*args, **kwargs)
+
+
+def board_url(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None):
     """Create a board from individual urls.
 
     Parameters
@@ -309,7 +320,7 @@ def board_urls(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None
     ...     "df_csv": "df_csv/20220214T163720Z-9bfad/",
     ...     "df_arrow": "df_arrow/20220214T163720Z-ad0c1/",
     ... }
-    >>> board = board_urls(github_raw, pin_paths)
+    >>> board = board_url(github_raw, pin_paths)
     >>> board.pin_list()
     ['df_csv', 'df_arrow']
     """
@@ -350,6 +361,31 @@ def board_rsconnect(
         CONNECT_API_KEY environment variable.
     **kwargs:
         Passed to the pins.board function.
+
+    Examples
+    --------
+    Use a server url or set the CONNECT_SERVER environt variable to connect:
+
+    ```python
+    server_url = "https://connect.rstudioservices.com"
+    board = board_rsconnect(server_url)
+    ```
+
+    In order to read a public pin, use board_manual with the public pin url.
+
+    ```python
+    # for a pin at https://connect.rstudioservices.com/content/3004/
+    board = board_url(
+        "https://connect.rstudioservices.com/content",
+        {"my_df": "3004/"}
+    )
+    board.pin_read("my_df")
+    ```
+
+    See Also
+    --------
+    board_url : board for connecting to individual pins, using a url or path.
+
     """
 
     # TODO: api_key can be passed in to underlying RscApi, equiv to R's manual mode

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -366,21 +366,21 @@ def board_rsconnect(
     --------
     Use a server url or set the CONNECT_SERVER environt variable to connect:
 
-    ```python
-    server_url = "https://connect.rstudioservices.com"
-    board = board_rsconnect(server_url)
-    ```
+    ::
+
+       server_url = "https://connect.rstudioservices.com"
+       board = board_rsconnect(server_url)
 
     In order to read a public pin, use board_manual with the public pin url.
 
-    ```python
-    # for a pin at https://connect.rstudioservices.com/content/3004/
-    board = board_url(
-        "https://connect.rstudioservices.com/content",
-        {"my_df": "3004/"}
-    )
-    board.pin_read("my_df")
-    ```
+    ::
+
+       # for a pin at https://connect.rstudioservices.com/content/3004/
+       board = board_url(
+           "https://connect.rstudioservices.com/content",
+           {"my_df": "3004/"}
+       )
+       board.pin_read("my_df")
 
     See Also
     --------

--- a/pins/rsconnect/fs.py
+++ b/pins/rsconnect/fs.py
@@ -201,7 +201,6 @@ class RsConnectFs(AbstractFileSystem):
         except RsConnectApiMissingContentError:
             # TODO: this could be seen as analogous to mkdir (which gets
             # called by pins anyway)
-            # TODO: hard-coded acl bad?
             content = self.api.post_content_item(parsed.content, access_type)
 
         # Create bundle (with manifest.json inserted if missing) ----

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -441,6 +441,23 @@ def test_board_rsc_pin_write_acl(df, board_short):
     assert content["access_type"] == "all"
 
 
+@pytest.mark.fs_rsc
+def test_board_rsc_pin_read_public(df, board_short):
+    from pins.boards import BoardManual
+
+    board_short.pin_write(df, "susan/mtcars", type="csv", access_type="all")
+
+    # note that users can also get this from the web ui
+    content_url = board_short.fs.info("susan/mtcars")["content_url"]
+
+    # shouldn't be a key set in env, but remove just in case
+    fs = fsspec.filesystem("http")
+    board_url = BoardManual("", fs, pin_paths={"rsc_public": content_url})
+
+    df_no_key = board_url.pin_read("rsc_public")
+    assert df_no_key.equals(df)
+
+
 # Manual Board Specific =======================================================
 
 from pins.boards import BoardManual  # noqa


### PR DESCRIPTION
* Adds support for reading public RStudio Connect pin content, using `board_manual`.
* Cleans up how board_manual constructs paths to pins.