### PR TITLE
ci: move compat check to own job, add workflow dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,41 +126,6 @@ jobs:
           pytest pins -m 'not fs_rsc and not fs_s3 and not fs_gcs and not fs_abfs and not skip_on_github'
 
 
-  check-cross-compatibility:
-    name: "Check cross lib compatibility"
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Install libcurl on Linux
-      run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev
-
-    # r ---
-
-    - uses: r-lib/actions/setup-r@v2
-      with:
-        use-public-rspm: true
-
-    - name: Install R dependencies
-      run: "install.packages('pins')"
-      shell: Rscript {0}
-
-    # python ---
-
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-    - name: Install py dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements/dev.txt
-        python -m pip install -e .
-
-    # write and test ---
-
-    - name: Run script/ci-compat-check
-      run: make ci-compat-check
-
   build-docs:
     name: "Build Docs"
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -6,6 +6,7 @@ on:
       r_pins_tag:
         description: "Tag or commit from pins-r (e.g. v1.0.3)"
         default: "__cran__"
+        required: true
   push:
     branches: ['main', 'dev-*']
   pull_request:
@@ -35,14 +36,14 @@ jobs:
     - name: Install R dependencies (from CRAN)
       run: "install.packages('pins')"
       shell: Rscript {0}
-      if: ${{ github.events.inputs.r_pins_tag == '__cran__' }}
+      if: ${{ inputs.r_pins_tag == '__cran__' }}
 
     - name: Install R dependencies (from github)
       run: "remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))"
       shell: Rscript {0}
       env:
         R_PINS_TAG: ${{ inputs.r_pins_tag }}
-      if: ${{ github.events.inputs.r_pins_tag != '__cran__' }}
+      if: ${{ inputs.r_pins_tag != '__cran__' }}
 
     # python ---
 

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      r_pins_tag:
+        description: "Tag or commit from pins-r (e.g. v1.0.3)"
+        default: "__cran__"
+  push:
+    branches: ['main', 'dev-*']
+  pull_request:
+  release:
+    types: [published]
+
+env:
+  PINS_ALLOW_RSC_SHORT_NAME: 1
+  PINS_FEATURE_PREVIEW: 1
+
+jobs:
+  check-cross-compatibility:
+    name: "Check cross lib compatibility"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install libcurl on Linux
+      run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev
+
+    # r ---
+
+    - uses: r-lib/actions/setup-r@v2
+      with:
+        use-public-rspm: true
+
+    - name: Install R dependencies (from CRAN)
+      run: "install.packages('pins')"
+      shell: Rscript {0}
+      if: ${{ inputs.r_pins_tag == '__cran__' }}
+
+    - name: Install R dependencies (from github)
+      run: "remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))"
+      shell: Rscript {0}
+      env:
+        R_PINS_TAG: ${{ inputs.r_pins_tag }}
+      if: ${{ inputs.r_pins_tag != '__cran__' }}
+
+    # python ---
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install py dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements/dev.txt
+        python -m pip install -e .
+
+    # write and test ---
+
+    - name: Run script/ci-compat-check
+      run: make ci-compat-check

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Cross compatibility
 
 on:
   workflow_dispatch:
@@ -35,14 +35,14 @@ jobs:
     - name: Install R dependencies (from CRAN)
       run: "install.packages('pins')"
       shell: Rscript {0}
-      if: ${{ inputs.r_pins_tag == '__cran__' }}
+      if: ${{ github.events.inputs.r_pins_tag == '__cran__' }}
 
     - name: Install R dependencies (from github)
       run: "remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))"
       shell: Rscript {0}
       env:
         R_PINS_TAG: ${{ inputs.r_pins_tag }}
-      if: ${{ inputs.r_pins_tag != '__cran__' }}
+      if: ${{ github.events.inputs.r_pins_tag != '__cran__' }}
 
     # python ---
 

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -36,14 +36,14 @@ jobs:
     - name: Install R dependencies (from CRAN)
       run: "install.packages('pins')"
       shell: Rscript {0}
-      if: ${{ inputs.r_pins_tag == '__cran__' }}
+      if: ${{ github.event.name != 'workflow_dispatch' || inputs.r_pins_tag == '__cran__' }}
 
     - name: Install R dependencies (from github)
       run: "remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))"
       shell: Rscript {0}
       env:
         R_PINS_TAG: ${{ inputs.r_pins_tag }}
-      if: ${{ inputs.r_pins_tag != '__cran__' }}
+      if: ${{ github.event.name == 'workflow_dispatch' && inputs.r_pins_tag != '__cran__' }}
 
     # python ---
 

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -40,6 +40,7 @@ jobs:
       shell: Rscript {0}
       env:
         R_PINS_TAG: v1.0.3
+        GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     # python ---
 

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -33,14 +33,20 @@ jobs:
       with:
         use-public-rspm: true
 
+    - name: Install R dependencies (from CRAN)
+      run: "install.packages('pins')"
+      shell: Rscript {0}
+      if: ${{ github.event.name != 'workflow_dispatch' || inputs.r_pins_tag == '__cran__' }}
+
     - name: Install R dependencies (from github)
       run: |
         install.packages("remotes")
         remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))
       shell: Rscript {0}
       env:
-        R_PINS_TAG: v1.0.3
+        R_PINS_TAG: ${{ inputs.r_pins_tag }}
         GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      if: ${{ github.event.name == 'workflow_dispatch' && inputs.r_pins_tag != '__cran__' }}
 
     # python ---
 

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -33,17 +33,13 @@ jobs:
       with:
         use-public-rspm: true
 
-    - name: Install R dependencies (from CRAN)
-      run: "install.packages('pins')"
-      shell: Rscript {0}
-      if: ${{ github.event.name != 'workflow_dispatch' || inputs.r_pins_tag == '__cran__' }}
-
     - name: Install R dependencies (from github)
-      run: "remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))"
+      run: |
+        install.packages("remotes")
+        remotes::install_github(paste0('rstudio/pins-r@', Sys.getenv('R_PINS_TAG')))
       shell: Rscript {0}
       env:
-        R_PINS_TAG: ${{ inputs.r_pins_tag }}
-      if: ${{ github.event.name == 'workflow_dispatch' && inputs.r_pins_tag != '__cran__' }}
+        R_PINS_TAG: v1.0.3
 
     # python ---
 


### PR DESCRIPTION
* Move compatibility check into its own workflow
* Adds workflow dispatch input, so you can choose the version of pins-r to install