### PR TITLE
chore: update authors, license, code of conduct

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-codeofconduct@rstudio.com.
+reported to the community leaders responsible for enforcement at codeofconduct@posit.co.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,17 +115,12 @@ community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
 Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
 
 For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
 
 [homepage]: https://www.contributor-covenant.org
-[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
-[Mozilla CoC]: https://github.com/mozilla/diversity
-[FAQ]: https://www.contributor-covenant.org/faq
-[translations]: https://www.contributor-covenant.org/translations

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 RStudio
+Copyright (c) 2023 pins-python authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 # Who maintains pins
 
-The pins-python package was created by and is currently maintained by Michael Chow <michael.chow@posit.co>. [Posit Software, PBC](https://posit.co/products/open-source/) is a copyright holder and funder of the vetiver package.
+The pins-python package was created by and is currently maintained by Michael Chow <michael.chow@posit.co>. [Posit Software, PBC](https://posit.co/products/open-source/) is a copyright holder and funder of this package.
 
-Several individuals in the community have taken an active role in helping to maintain vetiver and submit fixes. Those individuals are shown in the git changelog.
+Several individuals in the community have taken an active role in helping to maintain this package and submit fixes. Those individuals are shown in the git changelog.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,5 @@
+# Who maintains Vetiver
+
+The pins-python package was created by and is currently maintained by Michael Chow <michael.chow@posit.co>. [Posit Software, PBC](https://posit.co/products/open-source/) is a copyright holder and funder of the vetiver package.
+
+Several individuals in the community have taken an active role in helping to maintain vetiver and submit fixes. Those individuals are shown in the git changelog.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-# Who maintains Vetiver
+# Who maintains pins
 
 The pins-python package was created by and is currently maintained by Michael Chow <michael.chow@posit.co>. [Posit Software, PBC](https://posit.co/products/open-source/) is a copyright holder and funder of the vetiver package.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,11 +3,9 @@ name = pins
 description = Publish data sets, models, and other python objects, making it easy to share them across projects and with your colleagues.
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/rstudio/pins-python
-authors = [
-    {name="Michael Chow", email="michael.chow@posit.co"},
-    {name="Posit, PBC", email="michael.chow@posit.co"},
-]
+url = https://github.com/machow/pins-python
+author = Michael Chow
+author_email = mc_al_github@fastmail.com
 license = MIT
 keywords = data, tidyverse
 classifiers =
@@ -57,7 +55,7 @@ test =
     pytest-dotenv
     pytest-parallel
     s3fs
-    adlfs==2022.2.0
+    adlfs
     gcsfs
     fastparquet
     pyarrow

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,11 @@ name = pins
 description = Publish data sets, models, and other python objects, making it easy to share them across projects and with your colleagues.
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/machow/pins-python
-author = Michael Chow
-author_email = mc_al_github@fastmail.com
+url = https://github.com/rstudio/pins-python
+authors = [
+    {name="Michael Chow", email="michael.chow@posit.co"},
+    {name="Posit, PBC", email="michael.chow@posit.co"},
+]
 license = MIT
 keywords = data, tidyverse
 classifiers =

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ test =
     pytest-dotenv
     pytest-parallel
     s3fs
-    adlfs
+    adlfs==2022.2.0
     gcsfs
     fastparquet
     pyarrow


### PR DESCRIPTION
This PR closes https://github.com/rstudio/pins-python/issues/185. Note that I followed dplyr's license casing, and changed "Pins Python Authors" to "pins-python authors".