### PR TITLE
fix: RsConnectFs now strips protocol

### DIFF
--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -420,6 +420,15 @@ class RsConnectApi:
 
         _download_file(r, f_obj)
 
+    def misc_get_content_bundle_file_info(self, guid: str, id: str, name: str):
+
+        route = f"{self.server_url}/content/{guid}/_rev{id}/{name}"
+
+        r = self._raw_query(route, return_request=True)
+        r.raise_for_status()
+
+        return r.headers
+
     def misc_get_applications(
         self, filter: str, count: int = 1000, search: str = None
     ) -> Paginated[Sequence[Content]]:

--- a/pins/rsconnect/fs.py
+++ b/pins/rsconnect/fs.py
@@ -354,7 +354,7 @@ class RsConnectFs(AbstractFileSystem):
             raise ValueError(f"Unable to parse path: {path}")
 
     def _get_entity_from_path(self, path):
-        parsed = self.parse_path(path)
+        parsed = self.parse_path(self._strip_protocol(path))
 
         # guard against empty paths
         if isinstance(parsed, EmptyPath):

--- a/pins/tests/test_rsconnect_api.py
+++ b/pins/tests/test_rsconnect_api.py
@@ -363,6 +363,12 @@ def test_rsconnect_fs_info_root_ok(fs_short):
     assert susan == fs_short.info("susan")
 
 
+def test_rsconnect_fs_strips_protocol(fs_short):
+    # the critical thing here is that we can include the protocol (rsc://)
+    info = fs_short.info("rsc://susan")
+    assert info["username"] == "susan"
+
+
 # fs.exists ----
 
 


### PR DESCRIPTION
This PR enables pin's fsspec implementation (RsConnectFs) to work with the new fsspec GenericFileSystem, by ensuring the protocol gets stripped from any paths. For example, "rsc://my_user" now works.

This bug did not affect any pins behaviors, but fixing it allows us to query Posit Connect from duckdb...

```python
import pins
import duckdb

# note that my connect credentials are in a .env file
from dotenv import load_dotenv
load_dotenv()

# connect to board, register fs to duckdb ----
board = pins.board_connect("https://colorado.posit.co/rsc")
duckdb.register_filesystem(board.fs)

# look up bundle id ----
board.pin_meta("michael.chow/mtcars3")

# query with duckdb ----
query = duckdb.execute(
    "SELECT * FROM read_csv_auto('rsc://michael.chow/mtcars3/65421/mtcars3.csv')"
)

query.df()

```