### PR TITLE
Fixed link to github repo in quarto yaml

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -29,8 +29,8 @@ website:
             target: _blank
     right:
       - icon: github
-        href: https://github.com/rstudio/vetiver-python
-        aria-label: Vetiver python GitHub
+        href: https://github.com/rstudio/pins-python
+        aria-label: Pins python GitHub
   sidebar:
     style: "floating"
     collapse-level: 1


### PR DESCRIPTION
Hi there,

I noticed that there was a wrong link in the website header that led to the Vetiver package. I have fixed it to the Pins-Python package.

Cheers,
Anatoly