### PR TITLE
restrict `fsspec` less than 2023.9.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ zipsafe = False
 
 python_requires = >=3.7
 install_requires =
-    fsspec>=0.8.0
+    fsspec>=0.8.0,<2023.9.0
     pyyaml>=3.13
     xxhash>=1.0.0
     pandas>=0.23.0


### PR DESCRIPTION
In `fsspec==2023.9.0`, there are some breaking changes for pins's cache. We will specify which versions are known to work for the next release, and resolve the breaking changes in the subsequent release.