### PR TITLE
Set `versioned=False` for `board_url`

### DIFF
--- a/pins/boards.py
+++ b/pins/boards.py
@@ -89,8 +89,10 @@ class BaseBoard:
             Pin name.
 
         """
-        if self.versioned is False:
-            raise NotImplementedError()
+        if not self.versioned:
+            raise NotImplementedError(
+                "Cannot show versions for a board type that does not support versioning."
+            )
 
         if not self.pin_exists(name):
             raise PinsError("Cannot check version, since pin %s does not exist" % name)
@@ -235,6 +237,11 @@ class BaseBoard:
         versioned: Optional[bool] = None,
         created: Optional[datetime] = None,
     ) -> Meta:
+
+        if not self.versioned:
+            raise NotImplementedError(
+                "Can only write pins with boards that support versioning."
+            )
 
         if type == "feather":
             warn_deprecated(
@@ -453,6 +460,10 @@ class BaseBoard:
         version:
             Version identifier.
         """
+        if not self.versioned:
+            raise NotImplementedError(
+                "Can only write pins with boards that support versioning."
+            )
 
         pin_name = self.path_to_pin(name)
 

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -350,7 +350,7 @@ class BaseBoard:
             part of the pin version name.
         """
 
-        if versioned is False:
+        if not self.versioned:
             raise NotImplementedError(
                 "Can only write pins with boards that support versioning."
             )

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -66,10 +66,6 @@ class BaseBoard:
         self.board = str(board)
         self.fs = fs
         self.meta_factory = meta_factory
-
-        # if versioned is False:
-        #     raise NotImplementedError()
-
         self.versioned = versioned
         self.allow_pickle_read = allow_pickle_read
 
@@ -355,7 +351,9 @@ class BaseBoard:
         """
 
         if versioned is False:
-            raise NotImplementedError()
+            raise NotImplementedError(
+                "Can only write pins with boards that support versioning."
+            )
 
         if type == "file":
             raise NotImplementedError(

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -67,8 +67,8 @@ class BaseBoard:
         self.fs = fs
         self.meta_factory = meta_factory
 
-        if versioned is False:
-            raise NotImplementedError()
+        # if versioned is False:
+        #     raise NotImplementedError()
 
         self.versioned = versioned
         self.allow_pickle_read = allow_pickle_read
@@ -93,6 +93,9 @@ class BaseBoard:
             Pin name.
 
         """
+        if self.versioned is False:
+            raise NotImplementedError()
+
         if not self.pin_exists(name):
             raise PinsError("Cannot check version, since pin %s does not exist" % name)
 
@@ -350,6 +353,9 @@ class BaseBoard:
             A date to store in the Meta.created field. This field may be used as
             part of the pin version name.
         """
+
+        if versioned is False:
+            raise NotImplementedError()
 
         if type == "file":
             raise NotImplementedError(

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -370,7 +370,7 @@ def board_url(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None)
     --------
 
     ```python
-    github_raw = "https://raw.githubusercontent.com/machow/pins-python/main/pins/tests/pins-compat"
+    github_raw = "https://raw.githubusercontent.com/rstudio/pins-python/main/pins/tests/pins-compat"
     pin_paths = {
       "df_csv": "df_csv/20220214T163720Z-9bfad/",
       "df_arrow": "df_arrow/20220214T163720Z-ad0c1/",

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -399,7 +399,7 @@ def board_url(path: str, pin_paths: dict, cache=DEFAULT, allow_pickle_read=None)
     return BoardManual(
         path,
         fs,
-        versioned=True,
+        versioned=False,
         allow_pickle_read=allow_pickle_read,
         pin_paths=pin_paths,
     )

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -600,9 +600,8 @@ from pins.boards import BoardManual  # noqa
 
 
 def test_board_manual_http_file_download():
-    # TODO: change when repo is moved to RStudio
 
-    path = "https://raw.githubusercontent.com/machow/pins-python"
+    path = "https://raw.githubusercontent.com/rstudio/pins-python"
     license_path = "main/LICENSE"
 
     # use a simple cache, which automatically creates a temporary directory
@@ -630,7 +629,7 @@ def test_board_manual_pin_read():
     # see https://github.com/fsspec/filesystem_spec/issues/389
     fs = fsspec.filesystem("http", block_size=0)
     board = BoardManual(
-        "https://raw.githubusercontent.com/machow/pins-python/main/pins/tests/pins-compat",
+        "https://raw.githubusercontent.com/rstudio/pins-python/main/pins/tests/pins-compat",
         fs,
         pin_paths={
             "df_csv": "df_csv/20220214T163718Z-eceac/",

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -59,7 +59,7 @@ def construct_from_board(board):
 # copied from test_compat
 @pytest.mark.skip_on_github
 def test_constructor_board_url_data(tmp_cache, http_example_board_path, df_csv):
-    board = c.board_urls(
+    board = c.board_url(
         http_example_board_path,
         # could derive from example version path
         pin_paths={"df_csv": "df_csv/20220214T163720Z-9bfad/"},
@@ -77,13 +77,20 @@ def test_constructor_board_url_cache(tmp_cache, http_example_board_path, df_csv)
     # TODO: downloading a pin does not put files in the same directory, since
     # in this case we are hashing on the full url.
 
-    board = c.board_urls(
+    board = c.board_url(
         http_example_board_path,
         # could derive from example version path
         pin_paths={"df_csv": "df_csv/20220214T163718Z-eceac/"},
     )
 
     board.pin_read("df_csv")
+
+    # cannot read or view pin versions
+
+    with pytest.raises(NotImplementedError):
+        board.pin_write(df_csv)
+    with pytest.raises(NotImplementedError):
+        board.pin_versions("df_csv")
 
     # check cache ----
     http_dirs = list(tmp_cache.glob("http_*"))
@@ -107,7 +114,7 @@ def test_constructor_board_url_file(tmp_cache, http_example_board_path):
     # TODO: downloading a pin does not put files in the same directory, since
     # in this case we are hashing on the full url.
 
-    board = c.board_urls(
+    board = c.board_url(
         http_example_board_path,
         # could derive from example version path
         pin_paths={"df_csv": "df_csv/20220214T163718Z-eceac/df_csv.csv"},

--- a/pins/tests/test_constructors.py
+++ b/pins/tests/test_constructors.py
@@ -73,7 +73,9 @@ def test_constructor_board_url_data(tmp_cache, http_example_board_path, df_csv):
 
 @pytest.mark.xfail
 @pytest.mark.skip_on_github
-def test_constructor_board_url_cache(tmp_cache, http_example_board_path, df_csv):
+def test_constructor_board_url_cache(
+    tmp_cache, http_example_board_path, df_csv, tmp_path
+):
     # TODO: downloading a pin does not put files in the same directory, since
     # in this case we are hashing on the full url.
 
@@ -85,12 +87,19 @@ def test_constructor_board_url_cache(tmp_cache, http_example_board_path, df_csv)
 
     board.pin_read("df_csv")
 
-    # cannot read or view pin versions
+    # cannot write or view pin versions
 
     with pytest.raises(NotImplementedError):
         board.pin_write(df_csv)
     with pytest.raises(NotImplementedError):
         board.pin_versions("df_csv")
+    with pytest.raises(NotImplementedError):
+        board.pin_version_delete(name="df_csv", version="20220214T163718Z")
+    with pytest.raises(NotImplementedError):
+        df = pd.DataFrame({"x": [1, 2, 3]})
+        path = tmp_path / "data.csv"
+        df.to_csv(path, index=False)
+        board.pin_upload(path, "cool_pin")
 
     # check cache ----
     http_dirs = list(tmp_cache.glob("http_*"))


### PR DESCRIPTION
Currently, `board_url` is considered read-only without versioning support, but `versioned=True` on creation. This PR moves the NotImplementedError from the creation of any board with the attribute `versioned=False` and instead raises errors on relevant methods that should not be used with a read-only board.