### PR TITLE
docs: add examples with environment variables for `board_connect`

### DIFF
--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -442,7 +442,7 @@ def board_connect(
     board = board_connect()
     ```
 
-    Or use the `[dotenv]()` package to load other environment variable names from a `.env` file:
+    Or use the `[dotenv](https://saurabh-kumar.com/python-dotenv/)` package to load other environment variable names from a `.env` file:
 
     ```python
     import os

--- a/pins/constructors.py
+++ b/pins/constructors.py
@@ -435,11 +435,23 @@ def board_connect(
 
     Examples
     --------
-    Use a server URL or set the `CONNECT_SERVER` environt variable to connect:
+    Pins will automatically look for the `CONNECT_SERVER` and `CONNECT_API_KEY` environment variables:
 
     ```python
-    server_url = "https://connect.rstudioservices.com"
-    board = board_connect(server_url)
+    # where environment vars CONNECT_SERVER and CONNECT_API_KEY are set
+    board = board_connect()
+    ```
+
+    Or use the `[dotenv]()` package to load other environment variable names from a `.env` file:
+
+    ```python
+    import os
+    from dotenv import load_dotenv, find_dotenv
+    load_dotenv(find_dotenv())
+
+    api_key = os.getenv("MY_API_KEY")
+    server_url = os.getenv("MY_CONNECT_URL")
+    board = board_connect(server_url=server_url, api_key=api_key)
     ```
 
     In order to read a public pin, use `board_url()` with the public pin URL:

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -600,9 +600,8 @@ from pins.boards import BoardManual  # noqa
 
 
 def test_board_manual_http_file_download():
-    # TODO: change when repo is moved to RStudio
 
-    path = "https://raw.githubusercontent.com/machow/pins-python"
+    path = "https://raw.githubusercontent.com/rstudio/pins-python"
     license_path = "main/LICENSE"
 
     # use a simple cache, which automatically creates a temporary directory


### PR DESCRIPTION
closes #205 

add examples of using `board_connect` in scenarios where `CONNECT_SERVER` and `CONNECT_API_KEY` are set as well as when custom envvar names are used.