### PR TITLE
drop python 3.7 support, min fsspec>=2022.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         os: ["ubuntu-latest"]
         pytest_opts: ["--workers 4 --tests-per-worker 1"]
         requirements: [""]
         include:
           - os: "ubuntu-latest"
-            python: "3.7"
+            python: "3.8"
             requirements: "requirements/minimum.txt"
           - os: "macos-latest"
             python: "3.10"

--- a/pins/tests/helpers.py
+++ b/pins/tests/helpers.py
@@ -24,7 +24,7 @@ RSC_KEYS_FNAME = "pins/tests/rsconnect_api_keys.json"
 BOARD_CONFIG = {
     "file": {"path": ["PINS_TEST_FILE__PATH", None]},
     "s3": {"path": ["PINS_TEST_S3__PATH", "ci-pins"]},
-    "gcs": {"path": ["PINS_TEST_GCS__PATH", "ci-pins"]},
+    "gcs": {"path": ["PINS_TEST_GCS__PATH", "pins-python"]},
     "abfs": {"path": ["PINS_TEST_AZURE__PATH", "ci-pins"]},
     "rsc": {"path": ["PINS_TEST_RSC__PATH", RSC_SERVER_URL]},
 }

--- a/requirements/minimum.txt
+++ b/requirements/minimum.txt
@@ -1,5 +1,4 @@
-fsspec==0.8.0
-pyyaml==3.13
+fsspec==2022.2.0
 xxhash==1.0.0
 pandas==0.23.0
 jinja2==2.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ author_email = isabel.zimmerman@posit.co
 license = MIT
 keywords = data, tidyverse
 classifiers =
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -23,9 +22,9 @@ packages = find:
 include_package_data = True
 zipsafe = False
 
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
-    fsspec>=0.8.0,<2023.9.0
+    fsspec>=2022.2.0,<2023.9.0
     pyyaml>=3.13
     xxhash>=1.0.0
     pandas>=0.23.0


### PR DESCRIPTION
Update dependencies in anticipation of supporting more recent versions of python and fsspec