### PR TITLE
Switch from appdirs to platformdirs

### DIFF
--- a/pins/config.py
+++ b/pins/config.py
@@ -1,7 +1,7 @@
-import appdirs
 import os
-
 from types import SimpleNamespace
+
+import platformdirs
 
 PINS_NAME = "pins-py"
 PINS_ENV_DATA_DIR = "PINS_DATA_DIR"
@@ -27,11 +27,11 @@ def _interpret_int(env_var_name):
 
 
 def get_data_dir():
-    return os.environ.get(PINS_ENV_DATA_DIR, appdirs.user_data_dir(PINS_NAME))
+    return os.environ.get(PINS_ENV_DATA_DIR, platformdirs.user_data_dir(PINS_NAME))
 
 
 def get_cache_dir():
-    return os.environ.get(PINS_ENV_CACHE_DIR, appdirs.user_cache_dir(PINS_NAME))
+    return os.environ.get(PINS_ENV_CACHE_DIR, platformdirs.user_cache_dir(PINS_NAME))
 
 
 def get_allow_pickle_read(flag):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,8 +18,6 @@ aioitertools==0.11.0
     # via aiobotocore
 aiosignal==1.3.1
     # via aiohttp
-appdirs==1.4.4
-    # via pins (setup.cfg)
 appnope==0.1.3
     # via
     #   ipykernel
@@ -239,7 +237,9 @@ pickleshare==0.7.5
 pip-tools==7.1.0
     # via pins (setup.cfg)
 platformdirs==3.9.1
-    # via jupyter-core
+    # via
+    #   jupyter-core
+    #   pins (setup.cfg)
 pluggy==1.2.0
     # via pytest
 plum-dispatch==2.1.1

--- a/requirements/minimum.txt
+++ b/requirements/minimum.txt
@@ -5,5 +5,5 @@ jinja2==2.10.0
 joblib==0.12.0
 importlib-metadata==4.4
 importlib-resources==1.3
-appdirs<2.0.0
+platformdirs==3.9.1
 humanize==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     joblib>=0.12.0
     importlib-metadata>=4.4
     importlib-resources>=1.3
-    appdirs<2.0.0
+    platformdirs>=3.9.1
     humanize>=1.0.0
     requests
 


### PR DESCRIPTION
`appdirs` is abandoned:
https://github.com/ActiveState/appdirs

The active fork is `platformdirs`. Note that `platformdirs` was already a dev dependency for this project.