### PR TITLE
Remove syntax used as a workaround while Python 3.7 was being supported

### DIFF
--- a/pins/boards.py
+++ b/pins/boards.py
@@ -1077,7 +1077,7 @@ class BoardRsConnect(BaseBoard):
 
     @functools.cached_property
     def user_name(self):
-        return self.fs.api.get_user()
+        return self.fs.api.get_user()["username"]
 
     def prepare_pin_version(self, pin_dir_path, x, name: "str | None", *args, **kwargs):
         # TODO: should move board_deparse into utils, to avoid circular import


### PR DESCRIPTION
I noticed a few places in the code where there were workarounds associated with Python 3.7. Since support for 3.7 has been dropped, I have refactored to remove these workarounds.