### PR TITLE
Feature/153 support polars in pin_write to parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ board.pin_write(mtcars.head(), "mtcars", type="csv")
 
 Above, we saved the data as a CSV, but depending on what you’re saving
 and who else you want to read it, you might use the `type` argument to
-instead save it as a `joblib`, `parquet`, or `json` file.
+instead save it as a `joblib`, `parquet`, or `json` file. If you're using
+a `polars.DataFrame`, you can save to `parquet`.
 
-You can later retrieve the pinned data with `.pin_read()`:
+You can later retrieve the pinned data as a `pandas.DataFrame` with `.pin_read()`:
 
 ``` python
 board.pin_read("mtcars")

--- a/README.qmd
+++ b/README.qmd
@@ -66,8 +66,9 @@ board.pin_write(mtcars.head(), "mtcars", type="csv")
 Above, we saved the data as a CSV, but depending on
 what you’re saving and who else you want to read it, you might use the
 `type` argument to instead save it as a `joblib`, `parquet`, or `json` file.
+If you're using a `polars.DataFrame`, you can save to `parquet`.
 
-You can later retrieve the pinned data with `.pin_read()`:
+You can later retrieve the pinned data as a `pandas.DataFrame` with `.pin_read()`:
 
 ```{python}
 board.pin_read("mtcars")

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -235,13 +235,15 @@ def save_data(
 
 
 def default_title(obj, name):
-    import pandas as pd
+    df_family = _get_df_family(obj)
 
-    if isinstance(obj, pd.DataFrame):
+    if df_family in ("pandas", "polars"):
         # TODO(compat): title says CSV rather than data.frame
         # see https://github.com/machow/pins-python/issues/5
         shape_str = " x ".join(map(str, obj.shape))
         return f"{name}: a pinned {shape_str} DataFrame"
-    else:
+    elif df_family == "unknown":
         obj_name = type(obj).__qualname__
         return f"{name}: a pinned {obj_name} object"
+    else:
+        assert_never(df_family)

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -4,7 +4,7 @@ from .config import get_allow_pickle_read, PINS_ENV_INSECURE_READ
 from .meta import Meta
 from .errors import PinsInsecureReadError
 
-from typing import Sequence
+from typing import Literal, Sequence, assert_never
 
 # TODO: move IFileSystem out of boards, to fix circular import
 # from .boards import IFileSystem
@@ -15,12 +15,36 @@ REQUIRES_SINGLE_FILE = frozenset(["csv", "joblib", "file"])
 
 
 def _assert_is_pandas_df(x):
-    import pandas as pd
+    df_family = _get_df_family(x)
 
-    if not isinstance(x, pd.DataFrame):
+    if df_family != "pandas":
         raise NotImplementedError(
             "Currently only pandas.DataFrame can be saved to a CSV."
         )
+
+
+def _get_df_family(df) -> Literal["unknown", "pandas", "polars"]:
+    try:
+        import polars as pl
+    except ModuleNotFoundError:
+        is_polars_df = False
+    else:
+        is_polars_df = isinstance(df, pl.DataFrame)
+
+    import pandas as pd
+
+    is_pandas_df = isinstance(df, pd.DataFrame)
+
+    if not is_polars_df and not is_pandas_df:
+        return "unknown"
+    if is_polars_df and is_pandas_df:  # Hybrid DataFrame type!
+        return "unknown"
+    elif is_polars_df:
+        return "polars"
+    elif is_pandas_df:
+        return "pandas"
+    else:
+        assert_never(df)
 
 
 def load_path(meta, path_to_version):
@@ -174,9 +198,17 @@ def save_data(
         )
 
     elif type == "parquet":
-        _assert_is_pandas_df(obj)
-
-        obj.to_parquet(final_name)
+        df_family = _get_df_family(obj)
+        if df_family == "polars":
+            obj.write_parquet(final_name)
+        elif df_family == "pandas":
+            obj.to_parquet(final_name)
+        else:
+            msg = (
+                "Currently only pandas.DataFrame and polars.DataFrame can be saved to "
+                "a parquet file."
+            )
+            raise NotImplementedError(msg)
 
     elif type == "joblib":
         import joblib

--- a/pins/tests/test_drivers.py
+++ b/pins/tests/test_drivers.py
@@ -80,6 +80,36 @@ def test_driver_roundtrip(tmp_dir2, type_):
 @pytest.mark.parametrize(
     "type_",
     [
+        "parquet",
+    ],
+)
+def test_driver_polars_roundtrip(tmp_dir2, type_):
+    import polars as pl
+
+    df = pl.DataFrame({"x": [1, 2, 3]})
+
+    fname = "some_df"
+    full_file = f"{fname}.{type_}"
+
+    p_obj = tmp_dir2 / fname
+    res_fname = save_data(df, p_obj, type_)
+
+    assert Path(res_fname).name == full_file
+
+    meta = MetaRaw(full_file, type_, "my_pin")
+    pandas_df = load_data(
+        meta, fsspec.filesystem("file"), tmp_dir2, allow_pickle_read=True
+    )
+
+    # Convert from pandas to polars
+    obj = pl.DataFrame(pandas_df)
+
+    assert df.equals(obj)
+
+
+@pytest.mark.parametrize(
+    "type_",
+    [
         "json",
     ],
 )

--- a/pins/tests/test_drivers.py
+++ b/pins/tests/test_drivers.py
@@ -1,6 +1,7 @@
 import fsspec
 import pytest
 import pandas as pd
+import polars as pl
 
 from pathlib import Path
 
@@ -35,6 +36,7 @@ class ExC:
     [
         (pd.DataFrame({"x": [1, 2]}), "somename: a pinned 2 x 1 DataFrame"),
         (pd.DataFrame({"x": [1], "y": [2]}), "somename: a pinned 1 x 2 DataFrame"),
+        (pl.DataFrame({"x": [1, 2]}), "somename: a pinned 2 x 1 DataFrame"),
         (ExC(), "somename: a pinned ExC object"),
         (ExC().D(), "somename: a pinned ExC.D object"),
         ([1, 2, 3], "somename: a pinned list object"),

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -252,6 +252,8 @@ pluggy==1.5.0
     # via pytest
 plum-dispatch==2.5.1.post1
     # via quartodoc
+polars==1.2.1
+    # via pins (setup.cfg)
 portalocker==2.10.1
     # via msal-extensions
 prompt-toolkit==3.0.47

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ test =
     gcsfs
     fastparquet
     pyarrow
+    polars>=1.0.0
 
 
 [bdist_wheel]


### PR DESCRIPTION
To resolve #153.

A harder one is #233 - at the moment, `pandas` is the hard-coded return type for `pin_read`.