### PR TITLE
feat: multifile handling in `pin_upload`/`pin_download`

### DIFF
--- a/pins/boards.py
+++ b/pins/boards.py
@@ -246,7 +246,11 @@ class BaseBoard:
                 object_name = _p.name[:_base_len]
             else:
                 # multifile upload, keep list of filenames
-                object_name = x
+                object_name = []
+                for file in x:
+                    _p = Path(file)
+                    # _base_len = len(_p.name) - len("".join(_p.suffixes))
+                    object_name.append(_p.name)  # [:_base_len])
         else:
             object_name = None
 
@@ -375,12 +379,12 @@ class BaseBoard:
         if hash is not None:
             raise NotImplementedError("TODO: validate hash")
 
-        # Check that only a single file name was given
         fnames = [meta.file] if isinstance(meta.file, str) else meta.file
         pin_type = meta.type
 
         if len(fnames) > 1 and pin_type in REQUIRES_SINGLE_FILE:
             raise ValueError("Cannot load data when more than 1 file")
+
         pin_name = self.path_to_pin(name)
         files = []
 
@@ -698,7 +702,6 @@ class BaseBoard:
             p_obj = str(Path(pin_dir_path) / name)
         else:
             p_obj = str(Path(pin_dir_path) / object_name)
-
         # file is saved locally in order to hash, calc size
         file_names = save_data(x, p_obj, type, apply_suffix)
 

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -239,10 +239,13 @@ class BaseBoard:
             # than the pin name + a suffix (e.g. my_pin.csv).
             if isinstance(x, (tuple, list)) and len(x) == 1:
                 x = x[0]
+
+            if not isinstance(x, (list, tuple)):
                 _p = Path(x)
                 _base_len = len(_p.name) - len("".join(_p.suffixes))
                 object_name = _p.name[:_base_len]
             else:
+                # multifile upload, keep list of filenames
                 object_name = x
         else:
             object_name = None

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -893,7 +893,7 @@ class BoardManual(BaseBoard):
         meta = self.pin_meta(name, version)
 
         if isinstance(meta, MetaRaw):
-            f = load_file(meta, self.fs, None)
+            f = load_file(meta.file, self.fs, None, meta.type)
         else:
             raise NotImplementedError(
                 "TODO: pin_download currently can only read a url to a single file."

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -10,7 +10,7 @@ from .meta import Meta
 
 
 UNSAFE_TYPES = frozenset(["joblib"])
-REQUIRES_SINGLE_FILE = frozenset(["csv", "joblib", "file"])
+REQUIRES_SINGLE_FILE = frozenset(["csv", "joblib"])
 
 
 def _assert_is_pandas_df(x, file_type: str) -> None:
@@ -22,35 +22,24 @@ def _assert_is_pandas_df(x, file_type: str) -> None:
         )
 
 
-def load_path(meta, path_to_version):
-    # Check that only a single file name was given
-    fnames = [meta.file] if isinstance(meta.file, str) else meta.file
-
-    _type = meta.type
-
-    if len(fnames) > 1 and _type in REQUIRES_SINGLE_FILE:
-        raise ValueError("Cannot load data when more than 1 file")
-
+def load_path(filename: str, path_to_version, pin_type):
     # file path creation ------------------------------------------------------
-
-    if _type == "table":
+    if pin_type == "table":
         # this type contains an rds and csv files named data.{ext}, so we match
         # R pins behavior and hardcode the name
-        target_fname = "data.csv"
-    else:
-        target_fname = fnames[0]
+        filename = "data.csv"
 
     if path_to_version is not None:
-        path_to_file = f"{path_to_version}/{target_fname}"
+        path_to_file = f"{path_to_version}/{filename}"
     else:
         # BoardUrl doesn't have versions, and the file is the full url
-        path_to_file = target_fname
+        path_to_file = filename
 
     return path_to_file
 
 
-def load_file(meta: Meta, fs, path_to_version):
-    return fs.open(load_path(meta, path_to_version))
+def load_file(filename: str, fs, path_to_version, pin_type: str):
+    return fs.open(load_path(filename, path_to_version, pin_type))
 
 
 def load_data(

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -22,7 +22,7 @@ def _assert_is_pandas_df(x, file_type: str) -> None:
         )
 
 
-def load_path(filename: str, path_to_version, pin_type):
+def load_path(filename: str, path_to_version, pin_type=None):
     # file path creation ------------------------------------------------------
     if pin_type == "table":
         # this type contains an rds and csv files named data.{ext}, so we match
@@ -38,7 +38,7 @@ def load_path(filename: str, path_to_version, pin_type):
     return path_to_file
 
 
-def load_file(filename: str, fs, path_to_version, pin_type: str):
+def load_file(filename: str, fs, path_to_version, pin_type):
     return fs.open(load_path(filename, path_to_version, pin_type))
 
 
@@ -70,7 +70,7 @@ def load_data(
             "  * https://scikit-learn.org/stable/modules/model_persistence.html#security-maintainability-limitations"
         )
 
-    with load_file(meta, fs, path_to_version) as f:
+    with load_file(meta.file, fs, path_to_version, meta.type) as f:
         if meta.type == "csv":
             import pandas as pd
 

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -187,9 +187,9 @@ def save_data(
         import shutil
 
         if isinstance(obj, list):
-            for f, j in zip(obj, final_name):
+            for file, final in zip(obj, final_name):
                 with contextlib.suppress(shutil.SameFileError):
-                    shutil.copyfile(str(f), j)
+                    shutil.copyfile(str(file), final)
             return obj
         # ignore the case where the source is the same as the target
         else:

--- a/pins/drivers.py
+++ b/pins/drivers.py
@@ -208,7 +208,7 @@ def save_data(
                 shutil.copyfile(str(obj), final_name)
 
     else:
-        raise NotImplementedError(f"Cannot save type: {type}")
+        raise NotImplementedError(f"Cannot save type: {pin_type}")
 
     return final_name
 

--- a/pins/meta.py
+++ b/pins/meta.py
@@ -252,8 +252,6 @@ class MetaFactory:
                 file_size = [Path(f).stat().st_size for f in files]
                 version = Version.from_files(files, created)
 
-            # raise NotImplementedError("TODO: creating meta from multiple files")
-
         return Meta(
             title=title,
             description=description,

--- a/pins/meta.py
+++ b/pins/meta.py
@@ -245,7 +245,14 @@ class MetaFactory:
 
             raise NotImplementedError("Cannot create from file object.")
         else:
-            raise NotImplementedError("TODO: creating meta from multiple files")
+            if isinstance(files, (list, tuple)):
+                from pathlib import Path
+
+                file_name = files
+                file_size = [Path(f).stat().st_size for f in files]
+                version = Version.from_files(files, created)
+
+            # raise NotImplementedError("TODO: creating meta from multiple files")
 
         return Meta(
             title=title,

--- a/pins/meta.py
+++ b/pins/meta.py
@@ -248,7 +248,7 @@ class MetaFactory:
             if isinstance(files, (list, tuple)):
                 from pathlib import Path
 
-                file_name = files
+                file_name = [Path(f).name for f in files]
                 file_size = [Path(f).stat().st_size for f in files]
                 version = Version.from_files(files, created)
 

--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -263,7 +263,7 @@ class RsConnectApi:
         if guid is None:
             return User(self.query_v1("user"))
 
-        result = self.query_v1(f"user/{guid}")
+        result = self.query_v1(f"users/{guid}")
         return User(result)
 
     def get_users(

--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -263,7 +263,7 @@ class RsConnectApi:
         if guid is None:
             return User(self.query_v1("user"))
 
-        result = self.query_v1(f"users/{guid}")
+        result = self.query_v1(f"user/{guid}")
         return User(result)
 
     def get_users(

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -235,7 +235,7 @@ def test_board_pin_upload_path_list(board_with_cache, tmp_path):
 def test_board_pin_download_filename_multifile(board_with_cache, tmp_path):
     # create and save data
     df = pd.DataFrame({"x": [1, 2, 3]})
-    print(tmp_path)
+
     path1, path2 = tmp_path / "data1.csv", tmp_path / "data2.csv"
     df.to_csv(path1, index=False)
     df.to_csv(path2, index=False)
@@ -245,8 +245,11 @@ def test_board_pin_download_filename_multifile(board_with_cache, tmp_path):
     assert meta.type == "file"
     assert meta.file == ["data1.csv", "data2.csv"]
 
-    # (pin_path,) = board_with_cache.pin_download("cool_pin")
-    # assert Path(pin_path).name == "data.csv"
+    pin_path = board_with_cache.pin_download("cool_pin")
+
+    assert len(pin_path) == 2
+    assert Path(pin_path[0]).name == "data1.csv"
+    assert Path(pin_path[1]).name == "data2.csv"
 
 
 def test_board_pin_write_rsc_index_html(board, tmp_path: Path, snapshot):

--- a/pins/tests/test_boards.py
+++ b/pins/tests/test_boards.py
@@ -232,6 +232,23 @@ def test_board_pin_upload_path_list(board_with_cache, tmp_path):
     (pin_path,) = board_with_cache.pin_download("cool_pin")
 
 
+def test_board_pin_download_filename_multifile(board_with_cache, tmp_path):
+    # create and save data
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    print(tmp_path)
+    path1, path2 = tmp_path / "data1.csv", tmp_path / "data2.csv"
+    df.to_csv(path1, index=False)
+    df.to_csv(path2, index=False)
+
+    meta = board_with_cache.pin_upload([path1, path2], "cool_pin")
+
+    assert meta.type == "file"
+    assert meta.file == ["data1.csv", "data2.csv"]
+
+    # (pin_path,) = board_with_cache.pin_download("cool_pin")
+    # assert Path(pin_path).name == "data.csv"
+
+
 def test_board_pin_write_rsc_index_html(board, tmp_path: Path, snapshot):
     if board.fs.protocol != "rsc":
         pytest.skip()

--- a/pins/tests/test_drivers.py
+++ b/pins/tests/test_drivers.py
@@ -164,31 +164,23 @@ def test_driver_apply_suffix_false(tmp_path: Path):
 
 
 class TestLoadFile:
-    def test_multi_file_raises(self):
-        class _MockMetaMultiFile:
-            file: str | list[str] = ["a", "b"]
-            type: str = "csv"
-
-        with pytest.raises(ValueError, match="Cannot load data when more than 1 file"):
-            load_path(_MockMetaMultiFile(), None)
-
     def test_str_file(self):
         class _MockMetaStrFile:
             file: str = "a"
             type: str = "csv"
 
-        assert load_path(_MockMetaStrFile(), None) == "a"
+        assert load_path(_MockMetaStrFile().file, None, _MockMetaStrFile().type) == "a"
 
     def test_table(self):
         class _MockMetaTable:
             file: str = "a"
             type: str = "table"
 
-        assert load_path(_MockMetaTable(), None) == "data.csv"
+        assert load_path(_MockMetaTable().file, None, _MockMetaTable().type) == "data.csv"
 
     def test_version(self):
         class _MockMetaTable:
             file: str = "a"
             type: str = "csv"
 
-        assert load_path(_MockMetaTable(), "v1") == "v1/a"
+        assert load_path(_MockMetaTable().file, "v1", _MockMetaTable().type) == "v1/a"

--- a/pins/versions.py
+++ b/pins/versions.py
@@ -109,7 +109,7 @@ class Version(_VersionBase):
             combined_hashes = "".join(hashes)
 
             # Create an xxh64 hash of the combined string
-            hashes = xxh64(combined_hashes).hexdigest()
+            hashes = [xxh64(combined_hashes).hexdigest()]
 
         return cls(created, hashes[0])
 

--- a/pins/versions.py
+++ b/pins/versions.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import asdict, dataclass
 from datetime import datetime
+from pathlib import Path
 from typing import Mapping, Sequence
 
 from xxhash import xxh64
@@ -56,9 +57,7 @@ class Version(_VersionBase):
     def hash_file(f: IOBase, block_size: int = -1) -> str:
         # TODO: what kind of things implement the "buffer API"?
         hasher = xxh64()
-
         buf = f.read(block_size)
-
         while len(buf) > 0:
             hasher.update(buf)
             buf = f.read(block_size)
@@ -99,7 +98,7 @@ class Version(_VersionBase):
     ) -> Version:
         hashes = []
         for f in files:
-            hash_ = cls.hash_file(open(f, "rb") if isinstance(f, str) else f)
+            hash_ = cls.hash_file(open(f, "rb") if isinstance(f, (str, Path)) else f)
             hashes.append(hash_)
 
         if created is None:

--- a/pins/versions.py
+++ b/pins/versions.py
@@ -105,8 +105,11 @@ class Version(_VersionBase):
             created = datetime.now()
 
         if len(hashes) > 1:
-            hashes = [str(hash(tuple(hashes)))]
-            # raise NotImplementedError("Only 1 file may be currently be hashed")
+            # Combine the hashes into a single string
+            combined_hashes = "".join(hashes)
+
+            # Create an xxh64 hash of the combined string
+            hashes = xxh64(combined_hashes).hexdigest()
 
         return cls(created, hashes[0])
 

--- a/pins/versions.py
+++ b/pins/versions.py
@@ -106,7 +106,8 @@ class Version(_VersionBase):
             created = datetime.now()
 
         if len(hashes) > 1:
-            raise NotImplementedError("Only 1 file may be currently be hashed")
+            hashes = [str(hash(tuple(hashes)))]
+            # raise NotImplementedError("Only 1 file may be currently be hashed")
 
         return cls(created, hashes[0])
 


### PR DESCRIPTION
closes #314 
closes #311


Allows for multiple file paths to be passed into `pin_upload()`. This will NOT handle directories.