### PR TITLE
Add a spellchecker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
-exclude: "(.*\\.csv)|(^pins/tests/_snapshots)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
@@ -6,11 +5,18 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-        args: ["--unsafe"]
+        args: [--unsafe]
       - id: check-added-large-files
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.5.4" # Sync with pyproject.toml
+    rev: v0.5.4   # Sync with pyproject.toml
     hooks:
       - id: ruff
-        args: ["--fix"]
+        args: [--fix]
       - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
+exclude: (.*\.csv)|(^pins/tests/_snapshots)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: "(.*\\.csv)|(^pins/tests/_snapshots)"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
@@ -5,13 +6,13 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
-        args: [--unsafe]
+        args: ["--unsafe"]
       - id: check-added-large-files
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.5.4   # Sync with pyproject.toml
+    rev: "v0.5.4" # Sync with pyproject.toml
     hooks:
       - id: ruff
-        args: [--fix]
+        args: ["--fix"]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
@@ -19,4 +20,3 @@ repos:
       - id: codespell
         additional_dependencies:
           - tomli
-exclude: (.*\.csv)|(^pins/tests/_snapshots)

--- a/docs/customize-pins-metadata.qmd
+++ b/docs/customize-pins-metadata.qmd
@@ -3,7 +3,7 @@ title: Create consistent metadata for pins
 jupyter: python3
 ---
 
-The `metadata` argument in pins is flexible and can hold any kind of metadata that you can formulate as a `dict` (convertable to JSON).
+The `metadata` argument in pins is flexible and can hold any kind of metadata that you can formulate as a `dict` (convertible to JSON).
 In some situations, you may want to read and write with _consistent_ customized metadata;
 you can create functions to wrap [](`~pins.boards.BaseBoard.pin_write`) and [](`~pins.boards.BaseBoard.pin_read`) for your particular use case.
 

--- a/pins/boards.py
+++ b/pins/boards.py
@@ -133,8 +133,7 @@ class BaseBoard:
             # ensure pin and version exist
             if not self.fs.exists(self.construct_path([pin_name, version])):
                 raise PinsError(
-                    f"Pin {name} either does not exist, "
-                    f"or is missing version: {version}."
+                    f"Pin {name} either does not exist, or is missing version: {version}."
                 )
 
             selected_version = guess_version(version)
@@ -197,7 +196,7 @@ class BaseBoard:
             A specific pin version to retrieve.
         hash:
             A hash used to validate the retrieved pin data. If specified, it is
-            compared against the `pin_hash` field retrived by [](`~pins.boards.BaseBoard.pin_meta`).
+            compared against the `pin_hash` field retrieved by [](`~pins.boards.BaseBoard.pin_meta`).
 
         """
         meta = self.pin_fetch(name, version)
@@ -261,7 +260,7 @@ class BaseBoard:
 
         pin_name = self.path_to_pin(name)
 
-        # Pre-emptively fetch the most recent pin's meta if it exists - this is used
+        # Preemptively fetch the most recent pin's meta if it exists - this is used
         # for the force_identical_write check
         abort_if_identical = not force_identical_write and self.pin_exists(name)
         if abort_if_identical:
@@ -416,7 +415,7 @@ class BaseBoard:
             A specific pin version to retrieve.
         hash:
             A hash used to validate the retrieved pin data. If specified, it is
-            compared against the `pin_hash` field retrived by [](`~pins.boards.BaseBoard.pin_meta`).
+            compared against the `pin_hash` field retrieved by [](`~pins.boards.BaseBoard.pin_meta`).
 
         """
 

--- a/pins/rsconnect/api.py
+++ b/pins/rsconnect/api.py
@@ -335,7 +335,7 @@ class RsConnectApi:
         Note that this method returns None if successful. Otherwise, it raises an error.
         """
 
-        # if deletion is sucessful, then it will return an empty body, so we
+        # if deletion is successful, then it will return an empty body, so we
         # need to check the response manually.
         r = self.query_v1(f"content/{guid}", "DELETE", return_request=True)
 

--- a/pins/rsconnect/fs.py
+++ b/pins/rsconnect/fs.py
@@ -26,7 +26,7 @@ from .api import (
 
 def _not_impl_args_kwargs(args, kwargs):
     return NotImplementedError(
-        "Additional args and kwargs not supported." f"\nArgs: {args}\nKwargs: {kwargs}"
+        f"Additional args and kwargs not supported.\nArgs: {args}\nKwargs: {kwargs}"
     )
 
 
@@ -209,7 +209,7 @@ class RsConnectFs(AbstractFileSystem):
 
         if not (Path(lpath) / "manifest.json").exists():
             # TODO(question): does R pins copy content to tmp directory, or
-            # insert mainfest.json into the source directory?
+            # insert manifest.json into the source directory?
             cls_manifest.add_manifest_to_directory(lpath)
 
         bundle = self.api.post_content_bundle(content["guid"], lpath)

--- a/pins/tests/conftest.py
+++ b/pins/tests/conftest.py
@@ -41,7 +41,7 @@ def http_example_board_path():
     # backend = BoardBuilder("s3")
     # yield backend.create_tmp_board(str(PATH_TO_EXAMPLE_BOARD.absolute())).board
     # backend.teardown()
-    # TODO: could putting it in a publically available bucket folder
+    # TODO: could putting it in a publicly available bucket folder
     return (
         "https://raw.githubusercontent.com/machow/pins-python/main/pins/tests/pins-compat"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ universal = 1
 [tool.pytest.ini_options]
 markers = [
     "fs_file: mark test to only run on local filesystem",
-    "fs_s3: mark test to only run on AWS S3 bucket filesytem",
+    "fs_s3: mark test to only run on AWS S3 bucket filesystem",
     "fs_gcs: mark test to only run on Google Cloud Storage bucket filesystem",
     "fs_abfs: mark test to only run on Azure Datalake filesystem",
     "fs_rsc: mark test to only run on Posit Connect filesystem",
@@ -127,3 +127,6 @@ ignore = [
     "E501", # Line too long
     "A002", # The pins interface includes builtin names in args, e.g. hash, id, etc.
 ]
+
+[tool.codespell]
+skip = ["*.js"]


### PR DESCRIPTION
I found a few typos and thought I'd just run a spellchecker on the project. The only false positive was in a`.js` file, so I've set it to skip that.