### PR TITLE
Bump pre-commit action

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
-      - uses: pre-commit/action@v2.0.3
+      - uses: pre-commit/action@v3.0.1
 
   pyright:
     name: "Run Pyright"


### PR DESCRIPTION
As per https://github.com/rstudio/pins-python/actions/runs/14583410776/job/40904471773?pr=327
the version v2.0.3 depends on a deprecated service.