### PR TITLE
Use context managers for opening files

### DIFF
--- a/pins/databricks/fs.py
+++ b/pins/databricks/fs.py
@@ -67,8 +67,8 @@ class DatabricksFs(AbstractFileSystem):
                 if is_file:
                     rel_path = abs_path.relative_to(orig_path)
                     db_path = PurePath(rpath).joinpath(rel_path)
-                    file = open(abs_path, "rb")
-                    w.files.upload(str(db_path), BytesIO(file.read()), overwrite=True)
+                    with open(abs_path, "rb") as f:
+                        w.files.upload(str(db_path), BytesIO(f.read()), overwrite=True)
                 else:
                     _upload_files(abs_path)
 

--- a/pins/tests/test_rsconnect_api.py
+++ b/pins/tests/test_rsconnect_api.py
@@ -242,9 +242,8 @@ def test_rsconnect_api_get_content_bundle_archive(rsc_short):
 
             tmp_file.file.close()
 
-            tar = tarfile.open(tmp_file.name, "r:gz")
-            tar.extractall(path=tmp_dst)
-            tar.close()
+            with tarfile.open(tmp_file.name, "r:gz") as tar:
+                tar.extractall(path=tmp_dst)
 
             # run checks inside context handler for easier de-bugging ----
             p_src = Path(tmp_src)
@@ -421,7 +420,8 @@ def test_rsconnect_fs_get_data(fs_short):
         fs_short.get(f"susan/test-content/{bund1['id']}/index.html", tmp.name)
 
         # TODO: make more robust
-        assert "yo" in open(tmp.name).read()
+        with open(tmp.name) as f:
+            assert "yo" in f.read()
 
 
 # fs.put ----

--- a/pins/versions.py
+++ b/pins/versions.py
@@ -98,7 +98,11 @@ class Version(_VersionBase):
     ) -> Version:
         hashes = []
         for f in files:
-            hash_ = cls.hash_file(open(f, "rb") if isinstance(f, (str, Path)) else f)
+            if isinstance(f, (str, Path)):
+                with open(f, "rb") as f:
+                    hash_ = cls.hash_file(f)
+            else:
+                hash_ = cls.hash_file(f)
             hashes.append(hash_)
 
         if created is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ select = [
     "UP", # Upgrade to latest supported Python syntax
     "W",  # Style
     "A",  # Don't shadow built-ins
+    "SIM115", # Use context managers for file opens
 ]
 ignore = [
     "E501", # Line too long

--- a/script/setup-rsconnect/dump_api_keys.py
+++ b/script/setup-rsconnect/dump_api_keys.py
@@ -18,4 +18,5 @@ api_keys = {
     "derek": get_api_key("derek", "derek", "derek@example.com"),
 }
 
-json.dump(api_keys, open(OUT_FILE, "w"))
+with open(OUT_FILE, "w") as f:
+    json.dump(api_keys, f)


### PR DESCRIPTION
I have been getting `ResourceWarning`s for some calls to `Version.from_files` via `board.pin_upload`. I think it's due to un-closed file managers. In this PR I just enable a Ruff rule to detect this situation, and refactor to comply with the rule.

https://docs.astral.sh/ruff/rules/open-file-with-context-handler/