### PR TITLE
ci: skip databricks tests on fork PRs, and update cross-compat tests for latest pins-R

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
           python -m pip install -e .[test]
       - name: Run tests
         run: |
-          # TODO: better way to disable all cloud backend tests?
-          pytest pins -m 'not fs_rsc and not fs_s3 and not fs_gcs and not fs_abfs and not skip_on_github'
+          # Skip all tests requiring credentials, which aren't available on fork PRs.
+          pytest pins -m 'not fs_rsc and not fs_s3 and not fs_gcs and not fs_abfs and not fs_dbc and not skip_on_github'
 
 
   build-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             # ignore doctests
             pytest_opts: "-k pins/tests"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -131,7 +131,7 @@ jobs:
     name: "Build Docs"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
@@ -234,7 +234,7 @@ jobs:
     if: github.event_name == 'release'
     needs: [build-docs, tests]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -13,7 +13,7 @@ jobs:
     name: "Run pre-commit"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
       - uses: pre-commit/action@v3.0.1
 
@@ -21,7 +21,7 @@ jobs:
     name: "Run Pyright"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v4
         with:
           python-version: 3.13 # Use the maximum version supported by python-pins

--- a/.github/workflows/cross-compat.yml
+++ b/.github/workflows/cross-compat.yml
@@ -22,7 +22,7 @@ jobs:
     name: "Check cross lib compatibility"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install libcurl on Linux
       run: sudo apt-get update -y && sudo apt-get install -y libcurl4-openssl-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ universal = 1
 [tool.pytest.ini_options]
 markers = [
     "fs_file: mark test to only run on local filesystem",
-    # NOTE: if you add a new marker here for a backend that requires credentials, 
+    # NOTE: if you add a new marker here for a backend that requires credentials,
     # be sure to exclude it from the test command in .github/workflows/ci.yml
-    # in the "test-fork" job, to avoid failing tests where GitHub Actions 
+    # in the "test-fork" job, to avoid failing tests where GitHub Actions
     # secrets aren't available.
     "fs_s3: mark test to only run on AWS S3 bucket filesystem",
     "fs_gcs: mark test to only run on Google Cloud Storage bucket filesystem",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,10 @@ universal = 1
 [tool.pytest.ini_options]
 markers = [
     "fs_file: mark test to only run on local filesystem",
+    # NOTE: if you add a new marker here for a backend that requires credentials, 
+    # be sure to exclude it from the test command in .github/workflows/ci.yml
+    # in the "test-fork" job, to avoid failing tests where GitHub Actions 
+    # secrets aren't available.
     "fs_s3: mark test to only run on AWS S3 bucket filesystem",
     "fs_gcs: mark test to only run on Google Cloud Storage bucket filesystem",
     "fs_abfs: mark test to only run on Azure Datalake filesystem",

--- a/script/ci-compat-check/dump_r_pins.R
+++ b/script/ci-compat-check/dump_r_pins.R
@@ -1,5 +1,5 @@
 library(pins)
-args <- commandArgs(trailingOnly=TRUE)
+args <- commandArgs(trailingOnly = TRUE)
 
 board <- board_folder(args[1])
-board %>% pin_write(mtcars, "mtcars", type="csv")
+board |> pin_write(mtcars, "mtcars", type = "csv")

--- a/script/ci-compat-check/validate_py_to_r.R
+++ b/script/ci-compat-check/validate_py_to_r.R
@@ -1,6 +1,6 @@
 library(pins)
 
-args <- commandArgs(trailingOnly=TRUE)
+args <- commandArgs(trailingOnly = TRUE)
 
 
 # create board ----
@@ -13,13 +13,13 @@ board_r <- board_folder(args[2])
 
 cat("Checking mtcars pin\n")
 
-res_mtcars <- board_py %>% pin_read("mtcars")
-stopifnot(all.equal(res_mtcars, datasets::mtcars, check.attributes=FALSE))
+res_mtcars <- board_py |> pin_read("mtcars")
+stopifnot(all.equal(res_mtcars, datasets::mtcars, check.attributes = FALSE))
 
-meta_mtcars_py <- board_py %>% pin_meta("mtcars")
+meta_mtcars_py <- board_py |> pin_meta("mtcars")
 cat("\nPython meta:\n\n")
 print(meta_mtcars_py)
 
-meta_mtcars_r <- board_r %>% pin_meta("mtcars")
+meta_mtcars_r <- board_r |> pin_meta("mtcars")
 cat("\nR meta:\n\n")
 print(meta_mtcars_r)

--- a/script/stage_r_pins.R
+++ b/script/stage_r_pins.R
@@ -3,22 +3,22 @@ library(pins)
 df <- data.frame(x = 1:2, y = c("a", "b"))
 df_v2 <- data.frame(x = 1:2, y = c("a", "b"), z = 3:4)
 
-#board <- board_s3("ci-pins", prefix = "r-pins-test")
-board <- board_folder("pins/tests/pins-compat", versioned=TRUE)
+# board <- board_s3("ci-pins", prefix = "r-pins-test")
+board <- board_folder("pins/tests/pins-compat", versioned = TRUE)
 
-all_pins <- board %>% pin_list()
-board %>% pin_delete(all_pins)
+all_pins <- board |> pin_list()
+board |> pin_delete(all_pins)
 
 # write two versions of df as CSV ----
-board %>% pin_write(df, "df_csv", type="csv")
+board |> pin_write(df, "df_csv", type = "csv")
 Sys.sleep(2)
-board %>% pin_write(df_v2, "df_csv", type="csv")
+board |> pin_write(df_v2, "df_csv", type = "csv")
 
 # write two versions of df as arrow ----
-board %>% pin_write(df, "df_arrow", type="arrow")
+board |> pin_write(df, "df_arrow", type = "arrow")
 
 # write two versions of df as RDS ----
-board %>% pin_write(df, "df_rds", type="rds")
+board |> pin_write(df, "df_rds", type = "rds")
 
 # write unversioned pin as CSV
-board %>% pin_write(df, "df_unversioned", versioned=FALSE)
+board |> pin_write(df, "df_unversioned", versioned = FALSE)


### PR DESCRIPTION
I stumbled across https://github.com/rstudio/pins-python/pull/353 and saw that CI failed because it was a fork. This should fix it (and being from a fork, should confirm that). Then we can rebase that PR and it should be good.